### PR TITLE
Fix to add the api/tags endpoint

### DIFF
--- a/lib/real_world/blog/blog.ex
+++ b/lib/real_world/blog/blog.ex
@@ -122,4 +122,106 @@ defmodule RealWorld.Blog do
     |> String.downcase()
     |> String.replace(~r/[^\w-]+/u, "-")
   end
+
+  alias RealWorld.Blog.Tag
+
+  @doc """
+  Returns the list of tags.
+
+  ## Examples
+
+      iex> list_tags()
+      [%Tag{}, ...]
+
+  """
+  def list_tags do
+    Repo.all(Tag)
+  end
+
+  @doc """
+  Gets a single tag.
+
+  Raises `Ecto.NoResultsError` if the Tag does not exist.
+
+  ## Examples
+
+      iex> get_tag!(123)
+      %Tag{}
+
+      iex> get_tag!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_tag!(id), do: Repo.get!(Tag, id)
+
+  @doc """
+  Creates a tag.
+
+  ## Examples
+
+      iex> create_tag(%{field: value})
+      {:ok, %Tag{}}
+
+      iex> create_tag(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_tag(attrs \\ %{}) do
+    %Tag{}
+    |> tag_changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a tag.
+
+  ## Examples
+
+      iex> update_tag(tag, %{field: new_value})
+      {:ok, %Tag{}}
+
+      iex> update_tag(tag, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_tag(%Tag{} = tag, attrs) do
+    tag
+    |> tag_changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a Tag.
+
+  ## Examples
+
+      iex> delete_tag(tag)
+      {:ok, %Tag{}}
+
+      iex> delete_tag(tag)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_tag(%Tag{} = tag) do
+    Repo.delete(tag)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking tag changes.
+
+  ## Examples
+
+      iex> change_tag(tag)
+      %Ecto.Changeset{source: %Tag{}}
+
+  """
+  def change_tag(%Tag{} = tag) do
+    tag_changeset(tag, %{})
+  end
+
+  defp tag_changeset(%Tag{} = tag, attrs) do
+    tag
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+  end
 end

--- a/lib/real_world/blog/tag.ex
+++ b/lib/real_world/blog/tag.ex
@@ -1,0 +1,9 @@
+defmodule RealWorld.Blog.Tag do
+  use Ecto.Schema
+
+  schema "blog_tags" do
+    field :name, :string
+
+    timestamps()
+  end
+end

--- a/lib/real_world/web/controllers/tag_controller.ex
+++ b/lib/real_world/web/controllers/tag_controller.ex
@@ -1,0 +1,42 @@
+defmodule RealWorld.Web.TagController do
+  use RealWorld.Web, :controller
+
+  alias RealWorld.Blog
+  alias RealWorld.Blog.Tag
+
+  action_fallback RealWorld.Web.FallbackController
+
+  def index(conn, _params) do
+    tags = Blog.list_tags()
+    render(conn, "index.json", tags: tags)
+  end
+
+  def create(conn, %{"tag" => tag_params}) do
+    with {:ok, %Tag{} = tag} <- Blog.create_tag(tag_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", tag_path(conn, :show, tag))
+      |> render("show.json", tag: tag)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    tag = Blog.get_tag!(id)
+    render(conn, "show.json", tag: tag)
+  end
+
+  def update(conn, %{"id" => id, "tag" => tag_params}) do
+    tag = Blog.get_tag!(id)
+
+    with {:ok, %Tag{} = tag} <- Blog.update_tag(tag, tag_params) do
+      render(conn, "show.json", tag: tag)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    tag = Blog.get_tag!(id)
+    with {:ok, %Tag{}} <- Blog.delete_tag(tag) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/real_world/web/router.ex
+++ b/lib/real_world/web/router.ex
@@ -9,5 +9,6 @@ defmodule RealWorld.Web.Router do
     pipe_through :api
 
     resources "/articles", ArticleController, except: [:new, :edit]
+    resources "/tags", TagController, except: [:new, :edit]
   end
 end

--- a/lib/real_world/web/views/tag_view.ex
+++ b/lib/real_world/web/views/tag_view.ex
@@ -1,0 +1,16 @@
+defmodule RealWorld.Web.TagView do
+  use RealWorld.Web, :view
+  alias RealWorld.Web.TagView
+
+  def render("index.json", %{tags: tags}) do
+    %{tags: render_many(tags, TagView, "tag.json")}
+  end
+
+  def render("show.json", %{tag: tag}) do
+    %{tags: render_one(tag, TagView, "tag.json")}
+  end
+
+  def render("tag.json", %{tag: tag}) do
+    tag.name
+  end
+end

--- a/priv/repo/migrations/20170427211111_create_blog_tag.exs
+++ b/priv/repo/migrations/20170427211111_create_blog_tag.exs
@@ -1,0 +1,12 @@
+defmodule RealWorld.Repo.Migrations.CreateRealWorld.Blog.Tag do
+  use Ecto.Migration
+
+  def change do
+    create table(:blog_tags) do
+      add :name, :string
+
+      timestamps()
+    end
+
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,3 +9,9 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+
+alias RealWorld.Repo
+alias RealWorld.Blog
+
+Blog.create_tag(%{name: "reactjs"})
+Blog.create_tag(%{name: "angularjs"})

--- a/test/web/controllers/tag_controller_test.exs
+++ b/test/web/controllers/tag_controller_test.exs
@@ -1,0 +1,22 @@
+defmodule RealWorld.Web.TagControllerTest do
+  use RealWorld.Web.ConnCase
+
+  alias RealWorld.Blog
+
+  @create_attrs %{name: "some name"}
+
+  def fixture(:tag) do
+    {:ok, tag} = Blog.create_tag(@create_attrs)
+    tag
+  end
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  test "lists all entries on index", %{conn: conn} do
+    conn = get conn, tag_path(conn, :index)
+    assert json_response(conn, 200)["tags"] == []
+  end
+
+end


### PR DESCRIPTION
https://github.com/gothinkster/realworld/tree/master/api#list-of-tags

List of Tags
```
{
  "tags": [
    "reactjs",
    "angularjs"
  ]
}
```

This change has most of the boilerplate generated from phoenix, but the specs just need to show the `api/tags`. Please provide feedback.

Thanks!